### PR TITLE
fix: error code string type supported

### DIFF
--- a/src/LogService.spec.ts
+++ b/src/LogService.spec.ts
@@ -89,7 +89,7 @@ describe("LogService", () => {
   });
 
   describe("exception", () => {
-    it("should log logEntry", () => {
+    it("should log logEntry with enum error code", () => {
       const logger = new LogService();
       const logEntry: ILogErrorEntry = {
         context: "testing.context",
@@ -106,7 +106,29 @@ describe("LogService", () => {
         ...logEntry,
         level: Level.warn,
         category: Category.EXCEPTION,
-        message: ErrorCodeDefaultDesciption[ErrorCode.INVALID_BODY],
+        message: "",
+        correlationId: mockedCorrelationId,
+      });
+    });
+
+    it("should log logEntry with string error code", () => {
+      const logger = new LogService();
+      const logEntry: ILogErrorEntry = {
+        context: "testing.context",
+        errorCode: "INVALID",
+        metadata: {
+          data: "TEST",
+          description: "Testing Metadata",
+          value: 12,
+        },
+      };
+      logger.exception(logEntry);
+      expect(mockedPrivateLogger.log).toHaveBeenCalledTimes(1);
+      expect(mockedPrivateLogger.log).toHaveBeenCalledWith({
+        ...logEntry,
+        level: Level.warn,
+        category: Category.EXCEPTION,
+        message: "",
         correlationId: mockedCorrelationId,
       });
     });

--- a/src/LogService.ts
+++ b/src/LogService.ts
@@ -94,13 +94,13 @@ class LogService implements ILogger {
    * @param {string} [entry.context] name of class+method or function where the log is called (optional)
    * @param {string} [entry.message] string description of the logged action (optional)
    * @param {unknown} [entry.metadata] object for giving further information (optional)
-   * @param {ErrorCode} entry.errorCode standard code of the error
+   * @param {ErrorCode | string} entry.errorCode standard code of the error
    */
   public exception(entry: ILogErrorEntry): void {
     const { context, message, metadata, errorCode } = entry;
     this.logger.log({
       level: Level.warn,
-      message: message || ErrorCodeDefaultDesciption[errorCode],
+      message: message || "",
       category: Category.EXCEPTION,
       context,
       correlationId: correlator.getId(),
@@ -113,13 +113,13 @@ class LogService implements ILogger {
    * @param {string} [entry.context] name of class+method or function where the log is called (optional)
    * @param {string} [entry.message] string description of the logged action (optional)
    * @param {unknown} [entry.metadata] object for giving further information (optional)
-   * @param {ErrorCode} entry.errorCode standard code of the error
+   * @param {ErrorCode | string} entry.errorCode standard code of the error
    */
   public serverError(entry: ILogErrorEntry): void {
     const { context, message, metadata, errorCode } = entry;
     this.logger.log({
       level: Level.error,
-      message: message || ErrorCodeDefaultDesciption[errorCode],
+      message: message || "",
       category: Category.EXCEPTION,
       context,
       correlationId: correlator.getId(),

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,9 +14,18 @@ export type ILogEntry = {
 };
 
 /** Interface for a single error log register */
-export type ILogErrorEntry = ILogEntry & {
+export type ILogErrorEntry = {
+  /** name of class+method or function where the log is called */
+  context?: string;
+
+  /** description of the logged action */
+  message?: string;
+
+  /** object for giving further information */
+  metadata?: unknown;
+
   /** standard code of the error */
-  errorCode: ErrorCode;
+  errorCode: ErrorCode | string;
 };
 
 /** Interface that expose LogService */


### PR DESCRIPTION
## ¿Qué se hizo?

Se agrega el tipo string al error code de los logs de exception y server error.

## ¿Para qué se hizo?

Para no restringir únicamente el error code al enum declarado en la librería.